### PR TITLE
Add support for logging hashrates (+current)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ debug
 
 vendor/
 release/
+
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG GOLANG_VERSION=1.10.4
 RUN apt-get update && \
   apt-get install --no-install-recommends -y -q \
     curl \
+    pkg-config \
+    libzmq3-dev \
     build-essential \
     ca-certificates \
     git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# FROM ubuntu:14.04
 FROM pkienzle/opencl_docker
 MAINTAINER Julian Villella <julian@objectspace.io>
 
@@ -35,6 +34,7 @@ RUN chown -R $USER:$USER $GOPATH
 
 USER $USER
 
+RUN make clean
 RUN make dependencies
 # RUN make dev
 RUN make release

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 GPU and CPU miner for mining SEN. This miner runs in a command prompt and prints your hashrate along side the number of blocks you've mined. Most cards will see greatly increased hashrates by increasing the value of 'I' (default is 16, optimal is typically 20-25). Be careful with adjusting this parameter as it may crash the miner, or freeze the output. All available OpenCL-capable devices are detected and used in parallel.
 
-
 ## Install common dependencies (Ubuntu 16.04)
 
 #### On Ubuntu 16.04
@@ -54,18 +53,23 @@ OpenCL should already be installed. Nothing to do.
 
 ## Building project
 
-#### Binary releases
+##### Prerequisites
+
+* [ZeroMQ](http://zeromq.org/intro:get-the-software)
+* Drivers for your GPU
+
+### Binary releases
 
 Binaries for MacOS and Linux are available in the [corresponding releases](https://github.com/consensus-ai/sentient-miner/releases).
 
-#### Build from source (with Docker)
+### Build from source (with Docker)
 
-This build procedure expects the host to be using NVIDIA GPUs to run w/ GPU support (via the [NVIDIA Container Runtime for Docker](https://github.com/NVIDIA/nvidia-docker)). If this is doesn't meet the constraints for your system (e.x. you're running an AMD GPU) you don't have to use docker to build source.
+This build procedure expects the host to be using NVIDIA GPUs to run w/ GPU support (via the [NVIDIA Container Runtime for Docker](https://github.com/NVIDIA/nvidia-docker)). _If this is doesn't meet the constraints for your system (e.x. you're running an AMD GPU) you don't have to use docker to build source._
 
-##### Prerequisites
+##### Additional Prerequisites
 
 * Docker ([install instructions](https://docs.docker.com/install/))
-* NVIDIA PU drivers on host machine (e.x. [how to install on Amazon EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html))
+* NVIDIA GPU drivers on host machine (e.x. [how to install on Amazon EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html))
 
 ##### Build
 
@@ -105,9 +109,9 @@ $GOPATH/bin/sentient-miner \
   -user 269409be5afc296549bbf5f0831e31d50ef3510b82cde37194af5867fc8f084292576e8dad85.julian
 ```
 
-#### Build from source (without Docker)
+### Build from source (without Docker)
 
-##### Prerequisites
+##### Additional Prerequisites
 
 * go version 1.4.2 or above (I like to manage my go versions with [gvm](https://github.com/moovweb/gvm))
 * glide package manager ([install instructions](https://github.com/Masterminds/glide#install))

--- a/algorithms/sentient/miner.go
+++ b/algorithms/sentient/miner.go
@@ -53,8 +53,8 @@ func (m *Miner) Mine() {
 			GlobalItemSize:    m.GlobalItemSize,
 			Client:            m.Client,
 		}
-		go sdm.mine()
 
+		go sdm.mine()
 	}
 }
 

--- a/algorithms/sentient/stratumclient.go
+++ b/algorithms/sentient/stratumclient.go
@@ -56,6 +56,7 @@ func (sc *StratumClient) Start() {
 		sc.mutex.Unlock()
 	}()
 
+	sc.currentJob.JobID = ""
 	sc.DeprecateOutstandingJobs()
 
 	sc.stratumclient = &stratum.Client{}

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,20 @@
-hash: 8080c3aea1285ba51c810993abeea1e9ca03769139a54c4ad34876d7c6c05820
-updated: 2018-10-27T04:31:23.7581048Z
+hash: 910e17c702a5a3c54d959893d8504dc7ad636d40d6ee64fb488d594720d1cee0
+updated: 2018-11-16T19:06:18.1931119Z
 imports:
+- name: github.com/natefinch/atomic
+  version: a62ce929ffcc871a51e98c6eba7b20321e3ed62d
+- name: github.com/pebbe/zmq4
+  version: 3515f4e6f439e167f92f2b99a9497cf5ea8e3cea
 - name: github.com/robvanmieghem/go-opencl
   version: 5ca28f1a8220f79ffacbaa12e4dff1628b708307
   subpackages:
   - cl
 - name: golang.org/x/crypto
-  version: e84da0312774c21d64ee2317962ef669b27ffb41
+  version: 3d3f9f413869b949e48070b5bc593aa22cc2b8f2
   subpackages:
   - blake2b
 - name: golang.org/x/sys
-  version: 95b1ffbd15a57cc5abb3f04402b9e8ec0016a52c
+  version: 93218def8b18e66adbdab3eca8ec334700329f1f
   subpackages:
   - cpu
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,5 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - blake2b
+- package: github.com/pebbe/zmq4
+- package: github.com/natefinch/atomic

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	zmq "github.com/pebbe/zmq4"
 	"github.com/robvanmieghem/go-opencl/cl"
 	"github.com/consensus-ai/sentient-miner/algorithms/sentient"
 	"github.com/consensus-ai/sentient-miner/mining"
@@ -89,22 +90,57 @@ func main() {
 	}
 	miner.Mine()
 
+	socket, err := zmq.NewSocket(zmq.PUB)
+	if err != nil {
+		log.Println("Unable to create zmq socket for publishing hashrates")
+	}
+	defer socket.Close()
+
+	socketEndpoint, ok := os.LookupEnv("SENTIENT_MINER_CURRENT_HASHRATE_ENDPOINT")
+	if !ok {
+		socketEndpoint = "tcp://127.0.0.1:5555"
+	}
+	hashRatesSocketFrequency := 1 // 1 second
+	if socketFrequencyStr, ok := os.LookupEnv("SENTIENT_MINER_CURRENT_HASHRATE_FREQUENCY"); ok {
+		if i64, err := strconv.ParseInt(socketFrequencyStr, 10, 32); err == nil {
+			hashRatesSocketFrequency = int(i64)
+		}
+	}
+	hashRatesLogPath, ok := os.LookupEnv("SENTIENT_MINER_HASHRATES_LOG_PATH")
+	if !ok {
+		hashRatesLogPath = "./hashrates.log"
+	}
+	hashRatesLogFrequency := 10 * 60 // 10 minutes
+	if logFrequencyStr, ok := os.LookupEnv("SENTIENT_MINER_HASHRATES_LOG_FREQUENCY"); ok {
+		if i64, err := strconv.ParseInt(logFrequencyStr, 10, 32); err == nil {
+			hashRatesLogFrequency = int(i64)
+		}
+	}
+	maxLogLines := 10000
+	if maxLogLinesStr, ok := os.LookupEnv("SENTIENT_MINER_HASHRATES_LOG_MAX_LINES"); ok {
+		if i64, err := strconv.ParseInt(maxLogLinesStr, 10, 32); err == nil {
+			maxLogLines = int(i64)
+		}
+	}
+
+	socket.Bind(socketEndpoint)
+	socket.SetLinger(0)
+	stdOutSink := mining.NewHashRateStdOutSink()
+	socketSink := mining.NewHashRateSocketSink(socket, hashRatesSocketFrequency)
+	loggerSink := mining.NewHashRateLoggerSink(hashRatesLogPath, hashRatesLogFrequency, maxLogLines)
+
 	//Start printing out the hashrates of the different gpu's
-	hashRateReports := make([]float64, nrOfMiningDevices)
+	hashRateReports := make(map[int]float64)
 	for {
 		//No need to print at every hashreport, we have time
 		for i := 0; i < nrOfMiningDevices; i++ {
 			report := <-hashRateReportsChannel
 			hashRateReports[report.MinerID] = report.HashRate
 		}
-		fmt.Print("\r")
-		var totalHashRate float64
-		for minerID, hashrate := range hashRateReports {
-			fmt.Printf("%d-%.1f ", minerID, hashrate)
-			totalHashRate += hashrate
-		}
-		fmt.Printf("Total: %.1f MH/s  ", totalHashRate)
 
+		stdOutSink.SetCurrentHashRates(hashRateReports)
+		socketSink.SetCurrentHashRates(hashRateReports)
+		loggerSink.SetCurrentHashRates(hashRateReports)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version is the released version string of sentient-miner
-var Version = "v0.1.0"
+var Version = "v0.1.1"
 
 var intensity = 16
 var devicesTypesForMining = cl.DeviceTypeAll

--- a/mining/sinks.go
+++ b/mining/sinks.go
@@ -1,0 +1,151 @@
+package mining
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+	"bufio"
+
+	zmq "github.com/pebbe/zmq4"
+  "github.com/natefinch/atomic"
+)
+
+type HashRateSink interface {
+	SetCurrentHashRates(map[int]float64) error
+}
+
+type hashRateStdOutSink struct {}
+
+type hashRateSocketSink struct {
+	socket            *zmq.Socket
+	sendFrequency     int // Number of seconds between sends
+	lastSendTimestamp int64
+}
+
+type hashRateLoggerSink struct {
+	filePath         string
+	logFrequency     int // Number of seconds between logs
+	lastLogTimestamp int64
+	maxLogLines      int // Max number of lines the log file is allowed to grow to
+}
+
+func NewHashRateStdOutSink() *hashRateStdOutSink {
+	return &hashRateStdOutSink{}
+}
+
+func NewHashRateSocketSink(socket *zmq.Socket, sendFrequency int) *hashRateSocketSink {
+	return &hashRateSocketSink{
+		socket: socket,
+		sendFrequency: sendFrequency,
+		lastSendTimestamp: 0,
+	}
+}
+
+func NewHashRateLoggerSink(filePath string, logFrequency int, maxLogLines int) *hashRateLoggerSink {
+	return &hashRateLoggerSink{
+		filePath: filePath,
+		logFrequency: logFrequency,
+		lastLogTimestamp: 0,
+		maxLogLines: maxLogLines,
+	}
+}
+
+func (s *hashRateStdOutSink) SetCurrentHashRates(hashRates map[int]float64) error {
+	fmt.Print("\r")
+	var total float64
+	for minerID, hashRate := range hashRates {
+		fmt.Printf("%d-%.1f ", minerID, hashRate)
+		total += hashRate
+	}
+	fmt.Printf("Total: %.2f MH/s", total)
+	return nil
+}
+
+func (s *hashRateSocketSink) SetCurrentHashRates(hashRates map[int]float64) error {
+	var total float64
+	for _, hashRate := range hashRates {
+		total += hashRate
+	}
+
+	timestamp := time.Now().Unix()
+	if timestamp - s.lastSendTimestamp < int64(s.sendFrequency) {
+		return nil
+	}
+
+	s.lastSendTimestamp = timestamp
+	_, err := s.socket.Send(fmt.Sprintf("%.6f", total), 0)
+	return err
+}
+
+func (s *hashRateLoggerSink) SetCurrentHashRates(hashRates map[int]float64) error {
+	var total float64
+	for _, hashRate := range hashRates {
+		total += hashRate
+	}
+
+	timestamp := time.Now().Unix()
+	if timestamp - s.lastLogTimestamp < int64(s.logFrequency) {
+		return nil
+	}
+	s.lastLogTimestamp = timestamp
+
+	lines, err := readLines(s.filePath)
+	if err != nil {
+		log.Println("Unable to read hashrates log")
+		return err
+	}
+
+	offset := max(len(lines) - s.maxLogLines - 1, 0)
+	newLogLine := fmt.Sprintf("%d,%.6f", timestamp, total)
+	lines = append(lines, newLogLine)
+	lines = lines[offset:]
+	if err := atomicWriteLines(lines, s.filePath); err != nil {
+		log.Println("Unable to write hashrates log")
+		return err
+	}
+	return nil
+}
+
+func readLines(path string) ([]string, error) {
+  file, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
+  if err != nil {
+    return nil, err
+  }
+  defer file.Close()
+
+  var lines []string
+  scanner := bufio.NewScanner(file)
+	// scanner.Split(bufio.ScanLines)
+  for scanner.Scan() {
+    lines = append(lines, strings.TrimSpace(scanner.Text()))
+  }
+  return lines, scanner.Err()
+}
+
+func atomicWriteLines(lines []string, path string) error {
+  reader := strings.NewReader(strings.Join(lines, "\n"))
+  return atomic.WriteFile(path, reader)
+}
+
+func writeLines(lines []string, path string) error {
+  file, err := os.Create(path)
+  if err != nil {
+    return err
+  }
+  defer file.Close()
+
+  w := bufio.NewWriter(file)
+  for _, line := range lines {
+    fmt.Fprintln(w, line)
+  }
+  return w.Flush()
+}
+
+func max(x, y int) int {
+    if x > y {
+        return x
+    }
+    return y
+}

--- a/scripts/hashrate_consumer.py
+++ b/scripts/hashrate_consumer.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+"""
+Quick and dirty example script on how to consume sentient-miner hashrates
+(e.x. like the wallet app would). It prints the received current hash rates
+over zmq as well as the historical hash rates written to a log file.
+
+Prerequisites,
+- Python 3
+- `pip install pyzmq==17.1.2`
+
+If from within docker continer you can run,
+```
+apt-get install python3-dev
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py
+pip install pyzmq==17.1.2
+```
+
+Running,
+```
+# SENTIENT_MINER_CURRENT_HASHRATE_ENDPOINT=tcp://localhost:5555 \
+# SENTIENT_MINER_HASHRATES_LOG_PATH=../hashrates.log \
+python3 -m hashrate_consumer.py
+```
+"""
+
+import os
+import zmq
+
+
+def clearscreen():
+    if os.name == 'nt':
+        os.system('cls')
+    else:
+        os.system('clear')
+
+
+endpoint = os.environ.get('SENTIENT_MINER_CURRENT_HASHRATE_ENDPOINT', 'tcp://127.0.0.1:5555')
+log_path = os.environ.get('SENTIENT_MINER_HASHRATES_LOG_PATH', '../hashrates.log')
+
+context = zmq.Context()
+socket = context.socket(zmq.SUB)
+socket.connect(endpoint)
+
+socket.setsockopt(zmq.SUBSCRIBE, b'')
+socket.setsockopt(zmq.LINGER, 0)
+
+print('Connected to {}'.format(endpoint))
+
+while True:
+    hash_rate = float(socket.recv())  # Blocking
+    clearscreen()
+
+    print('Current Hash Rate: {:.6f}'.format(hash_rate))
+
+    # Inefficient file reading
+    print('Historical Hash Rates')
+    with open(log_path, 'rt') as f:
+        lines = f.read().splitlines()
+        last_lines = lines[-10:]
+        for line in ['\t{}'.format(l) for l in last_lines]:
+            print(line)


### PR DESCRIPTION
**This PR,**

Adds support for writing the current hashrate + a timestamp to a given log file path for consumers to see historical rates. The writes are atomic so consumers would not get partial line reads. This is a simple solution, consider using an actual structured datastore in the future. In addition, we publish the current hashrate to a zmp socket for consumers to get realtime hashrates. These features are all configurable through env vars. There's an example Python script of how a consumer (e.x. Sentient UI) would read from the zmq socket and log file.

**TODOs,**

- [x] Update README.md
- [ ] Bundle zmq library